### PR TITLE
broccoli-spelunk is discontinued

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var path = require('path');
 var fs   = require('fs');
 var mergeTrees = require('broccoli-merge-trees');
 var browserify = require('broccoli-browserify');
-var flattenFolder = require('broccoli-spelunk');
+var flatiron = require('broccoli-flatiron');
 var snippetFinder = require('./snippet-finder');
 
 module.exports = {
@@ -29,10 +29,8 @@ module.exports = {
       return snippetFinder(path);
     }).concat(snippets));
 
-    snippets = flattenFolder(snippets, {
-      outputFile: 'snippets.js',
-      mode: 'es6',
-      keepExtensions: true
+    snippets = flatiron(snippets, {
+      outputFile: 'snippets.js'
     });
 
     return this.mergeTrees([tree, snippets]);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "broccoli-static-compiler": "^0.1.4",
     "broccoli-merge-trees": "^0.1.4",
     "broccoli-browserify": "^0.1.0",
-    "broccoli-spelunk": "^0.1.2",
+    "broccoli-flatiron": "^0.0.0",
     "es6-promise": "^1.0.0",
     "broccoli-writer": "^0.1.1",
     "glob": "^4.0.4"


### PR DESCRIPTION
`broccoli-spelunk`, a dependency of this package, [is discontinued and no longer receiving updates](https://github.com/Rich-Harris/broccoli-spelunk/issues/2#issuecomment-71339752). It contains [some errors with handling promise rejections](https://github.com/minutebase/ember-inline-svg/issues/1#issuecomment-70625510) that won't get fixed.

I wrote an alternative specifically for [`ember-inline-svg`](https://github.com/minutebase/ember-inline-svg), that would work great with your codebase too: [`broccoli-flatiron`](https://github.com/buschtoens/broccoli-flatiron).

Your package is the only other dependent listed on npm, so I made this quick PR for you. Merge at will.