### PR TITLE
Using mergeTrees instead of this.mergeTrees to prevent deprecatin warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = {
       outputFile: 'snippets.js'
     });
 
-    return this.mergeTrees([tree, snippets]);
+    return mergeTrees([tree, snippets]);
   },
 
   treeForVendor: function(tree){
@@ -43,7 +43,7 @@ module.exports = {
       outputFile: 'highlight.js',
       require: [['./lib/index.js', {expose: 'highlight.js'}]]
     });
-    return this.mergeTrees([highlight, tree]);
+    return mergeTrees([highlight, tree]);
   },
 
   included: function(app) {


### PR DESCRIPTION
EmberCLI 0.2.3 throws deprecation warnings when plugins use `this.mergeTrees` and recommends to use `mergeTrees` from `broccoli-merge-trees` package. I just removed `this.` to use `mergeTrees` which was already included with the project.