### PR TITLE
Upgrades broccoli-merge-trees to ^0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "highlight.js": "^8.1.0",
     "broccoli-static-compiler": "^0.1.4",
-    "broccoli-merge-trees": "^0.1.4",
+    "broccoli-merge-trees": "^0.2.1",
     "broccoli-browserify": "^0.1.0",
     "broccoli-flatiron": "^0.0.0",
     "es6-promise": "^1.0.0",


### PR DESCRIPTION
```js
ENOENT: no such file or directory, stat '/home/elek/projects/formatjs/ember-intl/tmp/broccoli_merge_trees-input_base_path-brzL4hfU.tmp/1/dummy/templates/components/code-snippet.hbs'
Error: ENOENT: no such file or directory, stat '/home/elek/projects/formatjs/ember-intl/tmp/broccoli_merge_trees-input_base_path-brzL4hfU.tmp/1/dummy/templates/components/code-snippet.hbs'
    at Error (native)
    at Object.fs.statSync (fs.js:849:18)
    at checkIsDirectory (/home/elek/projects/formatjs/ember-intl/node_modules/ember-cli/node_modules/broccoli-merge-trees/index.js:149:17)
    at mergeRelativePath (/home/elek/projects/formatjs/ember-intl/node_modules/ember-cli/node_modules/broccoli-merge-trees/index.js:81:27)
    at mergeRelativePath (/home/elek/projects/formatjs/ember-intl/node_modules/ember-cli/node_modules/broccoli-merge-trees/index.js:128:15)
    at mergeRelativePath (/home/elek/projects/formatjs/ember-intl/node_modules/ember-cli/node_modules/broccoli-merge-trees/index.js:128:15)
    at mergeRelativePath (/home/elek/projects/formatjs/ember-intl/node_modules/ember-cli/node_modules/broccoli-merge-trees/index.js:128:15)
    at BroccoliMergeTrees.build (/home/elek/projects/formatjs/ember-intl/node_modules/ember-cli/node_modules/broccoli-merge-trees/index.js:26:3)
    at /home/elek/projects/formatjs/ember-intl/node_modules/ember-cli/node_modules/broccoli-merge-trees/node_modules/broccoli-plugin/read_compat.js:61:34
    at lib$rsvp$$internal$$tryCatch (/home/elek/projects/formatjs/ember-intl/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:493:16)
```

Upgrade broccoli-merge-trees fixes #10