### PR TITLE
npm v3 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,9 @@ module.exports = {
 
   treeForVendor: function(tree){
     // Package up the highlight.js source from its node module.
-    var src = this.treeGenerator(path.join(__dirname, 'node_modules', 'highlight.js'));
+
+    var src = this.treeGenerator(path.join(require.resolve('highlight.js'), '..', '..'));
+
     var highlight = browserify(src, {
       outputFile: 'highlight.js',
       require: [['./lib/index.js', {expose: 'highlight.js'}]]


### PR DESCRIPTION
Since npm flattens the deps, `path.join(__dirname, 'node_modules', 'highlight.js')` is no longer valid.