### PR TITLE
Add support for Emblem.js snippets

### DIFF
--- a/app/components/code-snippet.js
+++ b/app/components/code-snippet.js
@@ -52,6 +52,8 @@ export default Ember.Component.extend({
         return 'scss';
       case 'less':
         return 'less';
+      case 'emblem':
+        return 'emblem';
       }
     }
   })

--- a/snippet-finder.js
+++ b/snippet-finder.js
@@ -9,7 +9,7 @@ var path = require('path');
 
 function findFiles(srcDir) {
   return new _Promise(function(resolve, reject) {
-    glob(path.join(srcDir, "**/*.+(js|hbs|css|scss|less)"), function (err, files) {
+    glob(path.join(srcDir, "**/*.+(js|hbs|css|scss|less|emblem)"), function (err, files) {
       if (err) {
         reject(err);
       } else {


### PR DESCRIPTION
Added support for snippets in [.emblem](http://emblemjs.com/) files.

(This language isn't supported by highlight.js yet)