### PR TITLE
Work around highlight.js name conflict in build

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,14 +42,14 @@ module.exports = {
     var src = this.treeGenerator(path.join(require.resolve('highlight.js'), '..', '..'));
 
     var highlight = browserify(src, {
-      outputFile: 'highlight.js',
+      outputFile: 'browserified-highlight.js',
       require: [['./lib/index.js', {expose: 'highlight.js'}]]
     });
     return mergeTrees([highlight, tree]);
   },
 
   included: function(app) {
-    app.import('vendor/highlight.js');
+    app.import('vendor/browserified-highlight.js');
     app.import('vendor/highlight-style.css');
   }
 };


### PR DESCRIPTION
This addresses an error when calling `mergeTrees` in `treeForVendor`.
The browserified highlight.js outputFile had the same name as the
resolved highlight.js npm module directory.