### PR TITLE
Update highlight.js and add support for Typescript

### DIFF
--- a/app/components/code-snippet.js
+++ b/app/components/code-snippet.js
@@ -56,6 +56,8 @@ export default Ember.Component.extend({
         return 'less';
       case 'emblem':
         return 'emblem';
+      case 'ts':
+        return 'typescript';
       }
     }
   })

--- a/app/components/code-snippet.js
+++ b/app/components/code-snippet.js
@@ -47,7 +47,7 @@ export default Ember.Component.extend({
       case 'coffee':
         return 'coffeescript';
       case 'hbs':
-        return 'handlebars';
+        return 'htmlbars';
       case 'css':
         return 'css';
       case 'scss':

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "repository": "https://github.com/ef4/ember-code-snippet",
   "dependencies": {
-    "highlight.js": "^8.1.0",
+    "highlight.js": "^9.5.0",
     "broccoli-static-compiler": "^0.1.4",
     "broccoli-merge-trees": "^1.0.0",
     "broccoli-browserify": "^0.1.0",


### PR DESCRIPTION
This change makes syntax highlighting more accurate for Ember templates by using the `htmlbars` language and adds support for Typescript.