### PR TITLE
Improve unindent function

### DIFF
--- a/app/components/code-snippet.js
+++ b/app/components/code-snippet.js
@@ -13,15 +13,15 @@ export default Ember.Component.extend({
     if (!this.get('unindent')) {
       return src;
     }
-    var match, min, lines = src.split("\n");
+    var match, min, lines = src.split("\n").filter(l => l !== '');
     for (var i = 0; i < lines.length; i++) {
-      match = /^\s*/.exec(lines[i]);
+      match = /^[ \t]*/.exec(lines[i]);
       if (match && (typeof min === 'undefined' || min > match[0].length)) {
         min = match[0].length;
       }
     }
     if (typeof min !== 'undefined' && min > 0) {
-      src = src.replace(new RegExp("(\\n|^)\\s{" + min + "}", 'g'), "$1");
+      src = src.replace(new RegExp("^[ \t]{" + min + "}", 'gm'), "");
     }
     return src;
   },


### PR DESCRIPTION
Current function doesn't work with blank lines:

``` hbs
{{!-- BEGIN-SNIPPET dropdown-x-basic --}}
  {{some-thing}}

  {{another-thing}}
{{!-- END-SNIPPET --}}
```
