### PR TITLE
Add html filetype

### DIFF
--- a/snippet-finder.js
+++ b/snippet-finder.js
@@ -9,7 +9,7 @@ var path = require('path');
 
 function findFiles(srcDir) {
   return new _Promise(function(resolve, reject) {
-    glob(path.join(srcDir, "**/*.+(js|coffee|hbs|css|sass|scss|less|emblem)"), function (err, files) {
+    glob(path.join(srcDir, "**/*.+(js|coffee|html|hbs|css|sass|scss|less|emblem)"), function (err, files) {
       if (err) {
         reject(err);
       } else {


### PR DESCRIPTION
Sorry I didn't notice this before when I added the Sass filetype.  I just happened to want to include snippets from each of these types of files and noticed they weren't included.