### PR TITLE
Avoid using global `require` for babel@6 compat.

### DIFF
--- a/app/components/code-snippet.js
+++ b/app/components/code-snippet.js
@@ -2,7 +2,7 @@ import Ember from "ember";
 import Snippets from "../snippets";
 
 /* global require */
-var Highlight = require('highlight.js');
+var Highlight = self.require('highlight.js');
 
 export default Ember.Component.extend({
   tagName: 'pre',


### PR DESCRIPTION
`browserify` clobbers the global `require` so that it can intercept calls  to it and return modules from its own internal registry, then if not found it falls back to whatever global `require` existed.  This is bizarre, but works fine in babel@5 because the global `require` usage here is not modified.

However, when transpiled by babel@6 (to AMD) the following input:

```js
var Highlight = require('highlight.js');
```

Results in:

```js
define('dummy/components/code-snippet', ['highlight.js'], function(Highlight) {
});
```

Note that `highlight.js` is detected as a dependency (as if it had been `import Highlight from 'highlight.js';`).  Since our main loader registry is not aware of `highlight.js` having it as a dependency throws an error.

The solution here is to use `self.require` so that the `babel-plugin-transform-es2015-modules-amd` (which inherits from `babel-plugin-transform-es2015-modules-commonjs`) does not detect this `require` as an "import", and instead just leaves it alone.