### PR TITLE
Allow custom snippet regexes 😻

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,19 @@ template like this:
 {{code-snippet name="my-nice-example.js"}}
 ```
 
+You can also define your own regex to find snippets. Just use the `snippetRegexes` option:
+
+```js
+var app = new EmberAddon({
+ snippetRegexes: {
+   begin: /{{#element-example\sname=\"(\S+)\"/,
+   end: /{{\/element-example}}/,
+ }
+});
+```
+
+In the regex above everything in the `element-example` component block will be a snippet! Just make sure the first regex capture group is the name of the snippet.
+
 By default, the component will try to unindent the code block by
 removing whitespace characters from the start of each line until the
 code bumps up against the edge. You can disable this with:

--- a/index.js
+++ b/index.js
@@ -19,14 +19,21 @@ module.exports = {
     return this.app.options.snippetSearchPaths || ['app'];
   },
 
+  snippetRegexes: function() {
+    return [{
+      begin: /\bBEGIN-SNIPPET\s+(\S+)\b/,
+      end: /\bEND-SNIPPET\b/
+    }].concat(this.app.options.snippetRegexes || []);
+  },
 
   treeForApp: function(tree){
-    var snippets= mergeTrees(this.snippetPaths().filter(function(path){
+    var snippets = mergeTrees(this.snippetPaths().filter(function(path){
       return fs.existsSync(path);
     }));
 
+    var snippetRegexes = this.snippetRegexes();
     snippets = mergeTrees(this.snippetSearchPaths().map(function(path){
-      return snippetFinder(path);
+      return snippetFinder(path, snippetRegexes);
     }).concat(snippets));
 
     snippets = flatiron(snippets, {

--- a/snippet-finder.js
+++ b/snippet-finder.js
@@ -35,13 +35,9 @@ function extractSnippets(fileContent, regexes) {
         content.push(line);
       }
     } else {
-      // console.log('line=',line);
       var m = regexes.reduce(function(acc, currentRegex) {
-        // console.log('match -', line, currentRegex);
         return (regex = currentRegex).begin.exec(line);
       }, null);
-
-      // console.log('m=',m);
 
       if (m) {
         inside = true;
@@ -66,7 +62,6 @@ SnippetFinder.prototype.constructor = SnippetFinder;
 
 SnippetFinder.prototype.write = function (readTree, destDir) {
   var regexes = this.snippetRegexes;
-  console.log('regexes=',regexes);
 
   return readTree(this.inputTree).then(findFiles).then(function(files){
     files.forEach(function(filename){

--- a/snippet-finder.js
+++ b/snippet-finder.js
@@ -35,9 +35,10 @@ function extractSnippets(fileContent, regexes) {
         content.push(line);
       }
     } else {
-      var m = regexes.reduce(function(acc, currentRegex) {
-        return (regex = currentRegex).begin.exec(line);
-      }, null);
+      var m;
+      regex = regexes.find(function(regex) {
+        return m = regex.begin.exec(line);
+      });
 
       if (m) {
         inside = true;


### PR DESCRIPTION
This adds an option in the addon to allow users to use custom regexes! I updated the README accordingly:


> You can also define your own regex to find snippets. Just use the `snippetRegexes` option:
> 
> ```js
> var app = new EmberAddon({
>  snippetRegexes: {
>    begin: /{{#element-example\sname=\"(\S+)\"/,
>    end: /{{\/element-example}}/,
>  }
> });
> ```
> 
> In the regex above everything in the `element-example` component block will be a snippet! Just make sure the first regex capture group is the name of the snippet.

With this option, users are able to have any component mark their snippet! Using the custom regex in the example above, the following component would indicate a snippet:

```hbs
{{#element-example name="drivers-license"}}
  {{#if hasLicense}}
    You may drive 🚗
  {{else}}
    No hitting the roads for you yet mate! 🚧
  {{/if}}
{{/element-example}}
```

It would be really cool to have this merged. Cheers. 🌈

_For anyone that wants to use this right now, feel free to use [my fork](https://github.com/dunnkers/ember-code-snippet)_