### PR TITLE
update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "repository": "https://github.com/ef4/ember-code-snippet",
   "dependencies": {
-    "broccoli-flatiron": "^0.0.0",
+    "broccoli-flatiron": "^0.1.2",
     "broccoli-merge-trees": "^1.0.0",
     "broccoli-static-compiler": "^0.1.4",
     "broccoli-writer": "^0.1.1",


### PR DESCRIPTION
update dependencies because broccoli-flatiron fails by using lstatSync instead of statSync (fixed in 0.1.2)