### PR TITLE
Allow for excluding the file extension from the snippet name

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ var app = new EmberApp({
 });
 ```
 
+By default, the file extension from the containing file will automatically be included in the snippet name. For instance, the example above has `BEGIN-SNIPPET my-nice-example` in the JS source, and is subsequently referenced as `"my-nice-example.js"`. To disable this behavior, use the `includeFileExtensionInSnippetNames` option:
+
+```js
+var app = new EmberApp({
+  includeFileExtensionInSnippetNames: false
+});
+```
+
 # Syntax Highlighting Language Support
 
 We depend on [highlight.js](http://highlightjs.org/) for syntax highlighting. It supports 176 languages. But you probably don't want to build all of those into your app.
@@ -127,7 +135,7 @@ Out of the box, we only enable:
  - markdown
  - handlebars
  - htmlbars
- 
+
 If you want a different set, you can:
 
 1. Tell ember-code-snippet not to include highlight.js automatically for you:
@@ -146,7 +154,7 @@ If you want a different set, you can:
 4. Import it directly from your ember-cli-build.js file:
 
 ```js
-app.import('vendor/highlight.pack.js', { 
+app.import('vendor/highlight.pack.js', {
   using: [ { transformation: 'amd', as: 'highlight.js' } ]
 });
 ```

--- a/index.js
+++ b/index.js
@@ -28,6 +28,11 @@ module.exports = {
     }].concat(app.options.snippetRegexes || []);
   },
 
+  includeExtensions: function() {
+    var app = findHost(this);
+    return app.options.includeFileExtensionInSnippetNames !== false;
+  },
+
   includeHighlightJS: function() {
     var app = findHost(this);
     if (typeof app.options.includeHighlightJS === 'boolean') {
@@ -51,9 +56,13 @@ module.exports = {
       return fs.existsSync(path);
     }));
 
-    var snippetRegexes = this.snippetRegexes();
+    var snippetOptions = {
+      snippetRegexes: this.snippetRegexes(),
+      includeExtensions: this.includeExtensions()
+    };
+
     snippets = mergeTrees(this.snippetSearchPaths().map(function(path){
-      return snippetFinder(path, snippetRegexes);
+      return snippetFinder(path, snippetOptions);
     }).concat(snippets));
 
     snippets = flatiron(snippets, {

--- a/snippet-finder.js
+++ b/snippet-finder.js
@@ -50,26 +50,30 @@ function extractSnippets(fileContent, regexes) {
 }
 
 
-function SnippetFinder(inputTree, snippetRegexes) {
+function SnippetFinder(inputTree, options) {
   if (!(this instanceof SnippetFinder)) {
-    return new SnippetFinder(inputTree, snippetRegexes);
+    return new SnippetFinder(inputTree, options);
   }
   this.inputTree = inputTree;
-  this.snippetRegexes = snippetRegexes;
+  this.options = options;
 }
 
 SnippetFinder.prototype = Object.create(Writer.prototype);
 SnippetFinder.prototype.constructor = SnippetFinder;
 
 SnippetFinder.prototype.write = function (readTree, destDir) {
-  var regexes = this.snippetRegexes;
+  var regexes = this.options.snippetRegexes;
+  var includeExtensions = this.options.includeExtensions;
 
   return readTree(this.inputTree).then(findFiles).then(function(files){
     files.forEach(function(filename){
       var snippets = extractSnippets(fs.readFileSync(filename, 'utf-8'), regexes);
       for (var name in snippets){
-        fs.writeFileSync(path.join(destDir, name)+path.extname(filename),
-                         snippets[name]);
+        var destFile = path.join(destDir, name);
+        if (includeExtensions) {
+          destFile += path.extname(filename);
+        }
+        fs.writeFileSync(destFile, snippets[name]);
       }
     });
   });


### PR DESCRIPTION
This enables consumers to opt out of having the extension of the containing file automatically added to snippet names.

Since this addon doesn't follow the convention of nesting its configuration under a single key in app options, I struggled a little bit to come up with a reasonable name for this key—happy to adjust if you have thoughts.