### PR TITLE
feat(yaml): Add support for finding yaml snippets

### DIFF
--- a/snippet-finder.js
+++ b/snippet-finder.js
@@ -9,7 +9,7 @@ var path = require('path');
 
 function findFiles(srcDir) {
   return new _Promise(function(resolve, reject) {
-    glob(path.join(srcDir, "**/*.+(js|coffee|html|hbs|md|css|sass|scss|less|emblem)"), function (err, files) {
+    glob(path.join(srcDir, "**/*.+(js|coffee|html|hbs|md|css|sass|scss|less|emblem|yaml)"), function (err, files) {
       if (err) {
         reject(err);
       } else {


### PR DESCRIPTION
Similar to https://github.com/ef4/ember-code-snippet/pull/41 - add support for finding snippets in yaml files (in my case to support snippets pulled from i18n translation files)