### PR TITLE
Use the npm package name as app name

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var snippetFinder = require('./snippet-finder');
 var findHost = require('./utils/findHost');
 
 module.exports = {
-  name: 'Code Snippet Ember Component',
+  name: 'ember-code-snippet',
 
   snippetPaths: function() {
     var app = findHost(this);


### PR DESCRIPTION
Hello 👋 @ef4!

This PR replaces the _addon_ name specified on `index.js`, with the npm package name: `ember-code-snippet`. We were having an issue when tryinh to [blacklist](https://ember-cli.com/managing-dependencies#whitelisting-and-blacklisting-assets) this addon on _ember cli_.

```js
module.exports = function(defaults) {
  let app = new EmberApp(defaults, {
    addons: {
      blacklist: [
        'ember-code-snippet'
      ]
    }
  });

  //...
  return app.toTree();
};
```

<img width="436" alt="image 2018-05-26 at 12 40 49 am" src="https://user-images.githubusercontent.com/1156865/40572920-7750ba4c-607d-11e8-9f2e-655113a0259f.png">

And that's because ember-cli uses the `app.name` to filter the addons: https://github.com/ember-cli/ember-cli/blob/f876364e40a1d9fc4d07ead303744eb7d446f68b/lib/broccoli/ember-app.js#L596

Finally, thank you for this addon 🙏.
