### PR TITLE
Allow configuring snippet file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,12 +138,13 @@ Out of the box, we only enable:
 
 If you want a different set, you can:
 
-1. Tell ember-code-snippet not to include highlight.js automatically for you:
+1. Tell ember-code-snippet not to include highlight.js automatically for you. Also, include an array of file extensions corresponding to the languages you want to use. If ```snippetExtensions``` is not defined, the file extensions corresponding to the default list of supported languages will be used.
 
 ```js
   // in ember-cli-build.js
   var app = new EmberApp(defaults, {
-    includeHighlightJS: false
+    includeHighlightJS: false,
+    snippetExtensions: ['js','java','php']
   });
 ```
 

--- a/index.js
+++ b/index.js
@@ -28,6 +28,11 @@ module.exports = {
     }].concat(app.options.snippetRegexes || []);
   },
 
+  snippetExtensions: function() {
+    var app = findHost(this);
+    return app.options.snippetExtensions || ['js','ts','coffee','html','hbs','md','css','sass','scss','less','emblem','yaml'];
+  },
+
   includeExtensions: function() {
     var app = findHost(this);
     return app.options.includeFileExtensionInSnippetNames !== false;
@@ -58,7 +63,8 @@ module.exports = {
 
     var snippetOptions = {
       snippetRegexes: this.snippetRegexes(),
-      includeExtensions: this.includeExtensions()
+      includeExtensions: this.includeExtensions(),
+      snippetExtensions: this.snippetExtensions()
     };
 
     snippets = mergeTrees(this.snippetSearchPaths().map(function(path){

--- a/snippet-finder.js
+++ b/snippet-finder.js
@@ -8,9 +8,10 @@ var fs = require('fs');
 var path = require('path');
 
 
-function findFiles(srcDir) {
+function findFiles(srcDir, options) {
+  var fileNamePattern = `**/*.+(${options.snippetExtensions.join('|')})`;
   return new _Promise(function(resolve, reject) {
-    glob(path.join(srcDir, "**/*.+(js|ts|coffee|html|hbs|md|css|sass|scss|less|emblem|yaml)"), function (err, files) {
+    glob(path.join(srcDir, fileNamePattern), function (err, files) {
       if (err) {
         reject(err);
       } else {
@@ -84,7 +85,7 @@ SnippetFinder.prototype = Object.create(Plugin.prototype);
 SnippetFinder.prototype.constructor = SnippetFinder;
 
 SnippetFinder.prototype.build = function() {
-  return findFiles(this.inputPaths[0]).then((files) => {
+  return findFiles(this.inputPaths[0], this.options).then((files) => {
     writeSnippets(files, this.outputPath, this.options);
   });
 };


### PR DESCRIPTION
A fix for #58, which doesn't allow use of languages outside of the default set, even after using a custom version of highlight.js. This is due to the snippet finder only searching for file extensions from the default set of languages.

This change defines a new property in the configuration, `snippetExtensions`, which should correspond to the languages of the custom highlight.js build.

Also updated the README with instructions.