### PR TITLE
Fix bug related to windows line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,9 @@ insert_final_newline = true
 indent_style = space
 indent_size = 2
 
+[windows-line-endings.js]
+end_of_line = crlf
+
 [*.hbs]
 insert_final_newline = false
 

--- a/addon/components/code-snippet.js
+++ b/addon/components/code-snippet.js
@@ -14,7 +14,8 @@ export default Component.extend({
     if (!this.get('unindent')) {
       return src;
     }
-    let match, min, lines = src.split("\n").filter(l => l !== '');
+    let match, min;
+    var lines = src.match(/[^\r\n]+/g); // Split in non-empty lines (both linux + windows)
     for (let i = 0; i < lines.length; i++) {
       match = /^[ \t]*/.exec(lines[i]);
       if (match && (typeof min === 'undefined' || min > match[0].length)) {
@@ -34,7 +35,7 @@ export default Component.extend({
 
     return this._unindent(
       (snippet || "")
-        .replace(/^(\s*\n)*/, '')
+        .replace(/^(\s*\n)*/, '') // note: \s already matches \r, no need to check for [whitespace]\r\n
         .replace(/\s*$/, '')
     );
   }),

--- a/tests/integration/components/code-snippet-test.js
+++ b/tests/integration/components/code-snippet-test.js
@@ -8,20 +8,38 @@ module('Integration | Component | code-snippet', function(hooks) {
 
   test('it renders snippet', async function(assert) {
     await render(hbs`
-      // BEGIN-SNIPPET render-test
+      // BEGIN-SNIPPET render-test1
       function sample(){
         return 42;
       };
       // END-SNIPPET
-      
-      {{code-snippet id="snippet" name="render-test.js"}}
+
+      {{code-snippet id="snippet-1" name="render-test1.js"}}
     `);
 
-
-
-    assert.dom('pre#snippet').exists();
-    assert.dom('pre#snippet').hasText(
+    assert.dom('pre#snippet-1').exists();
+    assert.dom('pre#snippet-1').hasText(
       'function sample(){\n  return 42;\n};'
     );
+  });
+
+  test('Unindents snippet on Windows with multiple empty lines', async function(assert) {
+    await render(hbs`
+      {{code-snippet id="snippet-2" name="windows-line-endings.js"}}
+    `);
+
+    assert.dom('pre#snippet-2').exists();
+    assert.dom('pre#snippet-2').hasText(/^function sample/); // no spacing in front
+    assert.dom('pre#snippet-2').hasText(/\{[\r\n]{3}/); // has three new lines after bracket
+  });
+
+  test('Unindents snippet on Linux with multiple empty lines', async function(assert) {
+    await render(hbs`
+      {{code-snippet id="snippet-3" name="linux-line-endings.js"}}
+    `);
+
+    assert.dom('pre#snippet-3').exists();
+    assert.dom('pre#snippet-3').hasText(/^function sample/) // no spacing in front
+    assert.dom('pre#snippet-3').hasText(/\{[\r\n]{3}/); // has three new lines after bracket
   });
 });

--- a/tests/integration/snippets/linux-line-endings.js
+++ b/tests/integration/snippets/linux-line-endings.js
@@ -1,0 +1,9 @@
+  /* eslint-disable */
+  // BEGIN-SNIPPET linux-line-endings
+  function sample() {
+
+
+    console.log('There are two empty lines above that should not influence indentation.');
+    console.log('Note that this file is indented two spaces more than it should be, this is to test unindent.');
+  }
+  // END-SNIPPET

--- a/tests/integration/snippets/windows-line-endings.js
+++ b/tests/integration/snippets/windows-line-endings.js
@@ -1,0 +1,9 @@
+  /* eslint-disable */
+  // BEGIN-SNIPPET windows-line-endings
+  function sample() {
+
+
+    console.log('There are two empty lines above that should not influence indentation.');
+    console.log('Note that this file is indented two spaces more than it should be, this is to test unindent.');
+  }
+  // END-SNIPPET


### PR DESCRIPTION
Hello,

We are using your addon on Windows and noticed that for the following hbs snippet

```hbs
  <MainComponent>
    <ComponentA>
      Text
    </ComponentA>

    <ComponentA>
      Text
    </ComponentA>
  </MainComponent>
```

the snippet wouldn't be unindented (it would stay indented two spaces). This is because Windows uses `\r\n` as line endings and the logic that splits on `\n` would result in `\r` being still present on the line. That causes [`min`](https://github.com/ef4/ember-code-snippet/compare/master...NIPOSoftwareBV:red/win-line-endings?expand=1#diff-16206be37b856265dbce812d70600973R22) in to be set to 0 instead of 2.

I fixed the bug and wrote two additional test cases to cover this edge case. Let me know what you think.