### PR TITLE
Fixed a false positive test

### DIFF
--- a/tests/integration/helpers/get-code-snippet-test.js
+++ b/tests/integration/helpers/get-code-snippet-test.js
@@ -15,18 +15,21 @@ module('Integration | Helper | get-code-snippet', function(hooks) {
       // END-SNIPPET
       
       {{#with (get-code-snippet "render-test.js") as |snippet|}}
-        <div id="source">{{snippet.source}}</div>
+        <pre id="source"><code>{{snippet.source}}</code></pre>
         <div id="language">{{snippet.language}}</div>
         <div id="extension">{{snippet.extension}}</div>
       {{/with}}
     `);
 
-    assert.dom('#source').hasText('function sample(){\n  return 42;\n};');
+    assert.strictEqual(
+      this.element.querySelector('#source').textContent,
+      'function sample(){\n  return 42;\n};'
+    );
     assert.dom('#language').hasText('javascript'); // language is determined by file extension, so JS in this case
     assert.dom('#extension').hasText('js');
   });
 
-  test('it returns snippet w/ intented source', async function(assert) {
+  test('it returns snippet w/ indented source', async function(assert) {
     await render(hbs`
       // BEGIN-SNIPPET render-test
       function sample(){
@@ -34,14 +37,17 @@ module('Integration | Helper | get-code-snippet', function(hooks) {
       };
       // END-SNIPPET
       
-      {{#with (get-code-snippet "render-test.js" unintent=false) as |snippet|}}
-        <div id="source">{{snippet.source}}</div>
+      {{#with (get-code-snippet "render-test.js" unindent=false) as |snippet|}}
+        <pre id="source"><code>{{snippet.source}}</code></pre>
         <div id="language">{{snippet.language}}</div>
         <div id="extension">{{snippet.extension}}</div>
       {{/with}}
     `);
 
-    assert.dom('#source').hasText('      function sample(){\n        return 42;\n      };');
+    assert.strictEqual(
+      this.element.querySelector('#source').textContent,
+      '      function sample(){\n        return 42;\n      };'
+    );
     assert.dom('#language').hasText('javascript'); // language is determined by file extension, so JS in this case
     assert.dom('#extension').hasText('js');
   });

--- a/tests/unit/get-code-snippet-test.js
+++ b/tests/unit/get-code-snippet-test.js
@@ -6,24 +6,24 @@ module('Unit | getCodeSnippet', function() {
   test('it returns snippet', async function(assert) {
     let snippet = getCodeSnippet('render-test.js');
 
-    assert.equal(snippet.source, 'function sample(){\n  return 42;\n};');
-    assert.equal(snippet.language, 'javascript');
-    assert.equal(snippet.extension, 'js');
+    assert.strictEqual(snippet.source, 'function sample(){\n  return 42;\n};');
+    assert.strictEqual(snippet.language, 'javascript');
+    assert.strictEqual(snippet.extension, 'js');
   });
 
-  test('it returns snippet w/ intented source', async function(assert) {
+  test('it returns snippet w/ indented source', async function(assert) {
     let snippet = getCodeSnippet('render-test.js', false);
 
-    assert.equal(snippet.source, '      function sample(){\n        return 42;\n      };');
-    assert.equal(snippet.language, 'javascript');
-    assert.equal(snippet.extension, 'js');
+    assert.strictEqual(snippet.source, '      function sample(){\n        return 42;\n      };');
+    assert.strictEqual(snippet.language, 'javascript');
+    assert.strictEqual(snippet.extension, 'js');
   });
 
   test('it returns handlebars snippet', async function(assert) {
     let snippet = getCodeSnippet('static.hbs');
 
     assert.ok(snippet.source.includes('<p>I am a <strong>handlebars</strong> template!</p>'));
-    assert.equal(snippet.language, 'handlebars');
-    assert.equal(snippet.extension, 'hbs');
+    assert.strictEqual(snippet.language, 'handlebars');
+    assert.strictEqual(snippet.extension, 'hbs');
   });
 });


### PR DESCRIPTION
While studying the code, I noticed that a rendering test passed when `unintent=false` is sent to the `get-code-snippet` helper. We also want to keep in mind that QUnit DOM trims both the expected and actual values (unless we pass a regex). To check for indentation, I used `textContent` to get the raw output.